### PR TITLE
Issue05 redash to dasher web

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/vmware/captive-web-view.git
 [submodule "Keyboard/WebResources/dasher-web"]
 	path = Keyboard/WebResources/dasher-web
-	url = https://github.com/dasher-project/redash.git
+	url = https://github.com/dasher-project/dasher-web.git

--- a/Keyboard/WebResources/captivedasher.css
+++ b/Keyboard/WebResources/captivedasher.css
@@ -1,10 +1,9 @@
 /*
-(c) 2020 The ACE Centre-North, UK registered charity 1089313.
+(c) 2021 The ACE Centre-North, UK registered charity 1089313.
 MIT licensed, see https://opensource.org/licenses/MIT
 
 Some code copied from Captive Web View. See:  
-https://github.com/vmware/captive-web-view/blob/master/forAndroid/captivewebview/src/main/assets/library/pagebuilder.css
-
+https://github.com/vmware/captive-web-view/blob/main/Sources/CaptiveWebView/Resources/library/pagebuilder.css
 */
 
 :root {

--- a/Keyboard/WebResources/captivedasher.js
+++ b/Keyboard/WebResources/captivedasher.js
@@ -1,8 +1,7 @@
 // (c) 2021 The ACE Centre-North, UK registered charity 1089313.
 // MIT licensed, see https://opensource.org/licenses/MIT
 //
-// Some code copied from a Captive Web View sample, see:  
-// https://github.com/vmware/captive-web-view/blob/master/forAndroid/Captivity/src/main/assets/UserInterface/captivity.js
+
 
 // Import the Captive Web View simple page builder.
 import PageBuilder from "./dasher-web/browser/pagebuilder.js";

--- a/Keyboard/WebResources/keyboard.js
+++ b/Keyboard/WebResources/keyboard.js
@@ -2,7 +2,7 @@
 // MIT licensed, see https://opensource.org/licenses/MIT
 //
 // Some code copied from a Captive Web View sample, see:  
-// https://github.com/vmware/captive-web-view/blob/master/forAndroid/Captivity/src/main/assets/UserInterface/captivity.js
+// https://github.com/vmware/captive-web-view/blob/main/WebResources/Captivity/UserInterface/captivity.js
 
 // Import the Captive Web View simple page builder.
 import PageBuilder from "./pagebuilder.js";

--- a/Keyboard/WebResources/main.js
+++ b/Keyboard/WebResources/main.js
@@ -1,8 +1,8 @@
-// (c) 2020 The ACE Centre-North, UK registered charity 1089313.
+// (c) 2021 The ACE Centre-North, UK registered charity 1089313.
 // MIT licensed, see https://]]source.org/licenses/MIT
 //
 // Some code copied from a Captive Web View template. See:  
-// https://github.com/vmware/captive-web-view/blob/master/foriOS/readme.md
+// https://github.com/vmware/captive-web-view/tree/main/forApple
 
 class Main {
     constructor(bridge) {

--- a/Keyboard/forAndroid/readme.md
+++ b/Keyboard/forAndroid/readme.md
@@ -2,7 +2,8 @@
 This directory is for the proof-of-concept custom keyboard for Android.
 
 # Build Instructions
-These instructions have been tested with version 4.1.1 of Android Studio.
+These instructions have been tested with Android Studio Arctic Fox 2020.3.1
+Patch 3.
 
 -   There is a dependency on the library for Android in the captive-web-view
     submodule. Build the dependency first, as follows.
@@ -11,12 +12,11 @@ These instructions have been tested with version 4.1.1 of Android Studio.
     2.  Close any open projects, to avoid accidents.
     3.  Open as an existing project this location:
 
-            /where/you/cloned/redash/captive-web-view/forAndroid/
+            /where/you/cloned/dasher-captivewebview/Keyboard/forAndroid/captive-web-view/forAndroid
         
         Note: Don't select any file under that directory.
     
-    4.  Android Studio prompts you to Gradle Sync because it is unable to get
-        Gradle wrapper properties. Select OK and the project will build.
+    4.  Wait for any Gradle sync in Android Studio to finish.
     
     5.  Execute the Gradle task: forAndroid/Tasks/upload/uploadArchives
 
@@ -25,7 +25,7 @@ These instructions have been tested with version 4.1.1 of Android Studio.
     ![**Screen Capture:** Location of the Captive Web View build task](../../documents/ScreenCaptures/IDE/AndroidStudio_CaptiveWebView_build.png)
 
     That should create a maven repository under the directory:
-    `/where/you/cloned/redash/captive-web-view/m2repository/`
+    `/where/you/cloned/dasher-captivewebview/Keyboard/forAndroid/captive-web-view/m2repository/`
 
     The repository will contain the dependency and it can be included in the
     custom keyboard project.
@@ -36,13 +36,12 @@ These instructions have been tested with version 4.1.1 of Android Studio.
     2.  Close any open projects, to avoid accidents.
     3.  Open as an existing project this location:
 
-            /where/you/cloned/redash/Keyboard/forAndroid/
+            /where/you/cloned/dasher-captivewebview/Keyboard/forAndroid/
         
         Note: Don't select any file under that directory.
     
-    4.  Android Studio prompts you to Gradle Sync because it is unable to get
-        Gradle wrapper properties. Select OK and the project will synchronise
-        and configure its build. It might take a minute or two first time.
+    4.  Wait for any Gradle sync in Android Studio to finish. It might take a
+        minute or two first time.
 
 -   To install the keyboard via adb, execute the Gradle task:  
     DasherKeyboard/Tasks/install/installDebug
@@ -64,6 +63,6 @@ These instructions have been tested with version 4.1.1 of Android Studio.
     3.  Select 'Dasher Keyboard' in the alert.
 
 # License
-Copyright (c) 2020 The ACE Centre-North, UK registered charity 1089313.  
+Copyright (c) 2021 The ACE Centre-North, UK registered charity 1089313.  
 MIT licensed, see
 [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT).

--- a/Keyboard/foriOS/readme.md
+++ b/Keyboard/foriOS/readme.md
@@ -18,7 +18,7 @@ Notes
 
 -   Instructions for adding Captive Web View for iOS are in its repository,
     here:  
-    [https://github.com/vmware/captive-web-view/tree/master/foriOS](https://github.com/vmware/captive-web-view/tree/master/foriOS)
+    [https://github.com/vmware/captive-web-view/tree/main/forApple](https://github.com/vmware/captive-web-view/tree/main/forApple)
 
     You might have to build the Captive Web View target separately before you
     can build the custom keyboard.
@@ -74,6 +74,6 @@ Notes
 
 License
 =======
-Copyright (c) 2020 The ACE Centre-North, UK registered charity 1089313.  
+Copyright (c) 2021 The ACE Centre-North, UK registered charity 1089313.  
 MIT licensed, see
 [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT).

--- a/Keyboard/foriOS/readme.md
+++ b/Keyboard/foriOS/readme.md
@@ -10,18 +10,19 @@ Notes
 
     Contents of the workspace are as follows.
 
-    -   Keyboard, the Xcode project for this proof of concept.
-        -   browser, reference to the HTML, CSS, and JavaScript.
-        -   ContainingApplication, required to package the keyboard.
-        -   Extension, the actual custom keyboard code.
-    -   CaptiveWebView, reference to the submodule.
+    -   DasherApp, the Xcode project for this proof of concept.
+        -   WebResources, reference to the HTML, CSS, and JavaScript.
+        -   Keyboard, code specific to the custom keyboard extension.
+        -   App, code specific to the containing app whose bundle includes the
+            keyboard.
+        -   Common, code shared by the app and the extension.
+    -   CaptiveWebView, reference to the Swift package for the Captive Web View
+        code. The Captive Web View repository is compatible with Swift Package
+        Manager in Xcode.
 
 -   Instructions for adding Captive Web View for iOS are in its repository,
     here:  
     [https://github.com/vmware/captive-web-view/tree/main/forApple](https://github.com/vmware/captive-web-view/tree/main/forApple)
-
-    You might have to build the Captive Web View target separately before you
-    can build the custom keyboard.
 
 -   ToDo: Raise an issue on Captive Web View about the retain cycle and message
     handler.

--- a/documents/ScreenCaptures/readme.md
+++ b/documents/ScreenCaptures/readme.md
@@ -46,7 +46,7 @@ custom keyboard for iOS, above.
 
 # Document Information
 This content is part of the Dasher project and is under revision control here:  
-[https://github.com/dasher-project/redash](https://github.com/dasher-project/redash)
+[https://github.com/dasher-project/dasher-captivewebview](https://github.com/dasher-project/dasher-captivewebview)
 
 (c) 2020 The ACE Centre-North, UK registered charity 1089313.  
 MIT licensed, see [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)

--- a/documents/ScreenCaptures/readme.md
+++ b/documents/ScreenCaptures/readme.md
@@ -48,5 +48,5 @@ custom keyboard for iOS, above.
 This content is part of the Dasher project and is under revision control here:  
 [https://github.com/dasher-project/dasher-captivewebview](https://github.com/dasher-project/dasher-captivewebview)
 
-(c) 2020 The ACE Centre-North, UK registered charity 1089313.  
+(c) 2021 The ACE Centre-North, UK registered charity 1089313.  
 MIT licensed, see [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)

--- a/documents/readme.md
+++ b/documents/readme.md
@@ -1,2 +1,2 @@
 See also the
-[documentation pages in the Dasher Web (aka redash) repository](https://github.com/dasher-project/redash/tree/master/documents).
+[documentation pages in the Dasher Web (previously redash) repository](https://github.com/dasher-project/dasher-web/tree/master/documents).

--- a/documents/readme.md
+++ b/documents/readme.md
@@ -1,2 +1,2 @@
 See also the
-[documentation pages in the Dasher Web (previously redash) repository](https://github.com/dasher-project/dasher-web/tree/master/documents).
+[documentation pages in the Dasher Web (previously redash) repository](https://github.com/dasher-project/dasher-web/tree/main/documents).

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,8 @@
-[![Build Status](https://travis-ci.com/dasher-project/redash.svg?branch=master)](https://travis-ci.com/dasher-project/redash)
-
 # Dasher Web in Captive Web View
 This repository is for mobile and desktop apps that package Dasher Web in a
 Captive Web View.
 
--   [Dasher Web](https://github.com/dasher-project/redash) is an Open Source
+-   [Dasher Web](https://github.com/dasher-project/dasher-web) is an Open Source
     re-implementation in web technologies of the original Dasher zooming text
     entry user interface.
 -   [Captive Web View](https://github.com/vmware/captive-web-view) is a VMware


### PR DESCRIPTION
Resolves #5

I think I found everything that referred to `redash` and `master` in this repository and changed them to refer to `dasher-web` and `main`. Then I walked through the build instructions and updated some more items.